### PR TITLE
Get assertion from correct parameter, and check type

### DIFF
--- a/lib/passport-oauth2-jwt-bearer/strategy.js
+++ b/lib/passport-oauth2-jwt-bearer/strategy.js
@@ -35,12 +35,12 @@ util.inherits(Strategy, passport.Strategy);
 * @api protected
 */
 Strategy.prototype.authenticate = function(req) {
-  if (!req.body || (!req.body['assertion'])) {
+  if (!req.body || (!req.body['client_assertion'])) {
     return this.fail();
   }
 
   var contents = [],
-      jwtBearer = req.body['assertion'],
+      jwtBearer = req.body['client_assertion'],
       separator = '.',
       self = this;
 

--- a/lib/passport-oauth2-jwt-bearer/strategy.js
+++ b/lib/passport-oauth2-jwt-bearer/strategy.js
@@ -35,14 +35,19 @@ util.inherits(Strategy, passport.Strategy);
 * @api protected
 */
 Strategy.prototype.authenticate = function(req) {
-  if (!req.body || (!req.body['client_assertion'])) {
+  if (!req.body || (!req.body['client_assertion_type'] || !req.body['client_assertion'])) {
     return this.fail();
   }
 
   var contents = [],
+      type  = req.body['client_assertion_type']
       jwtBearer = req.body['client_assertion'],
       separator = '.',
       self = this;
+
+  if (type != 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer') {
+    return this.fail();
+  }
 
   contents = jwtBearer.split(separator);
 

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -59,7 +59,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -110,7 +110,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -160,7 +160,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -205,7 +205,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -253,7 +253,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         //req.body = {};
-        //req.body['assertion'] = contents.join('.');
+        //req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -300,7 +300,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -347,7 +347,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -394,7 +394,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -441,7 +441,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -499,7 +499,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -59,6 +59,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -110,6 +111,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -160,6 +162,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -205,6 +208,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -253,6 +257,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         //req.body = {};
+        //req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         //req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -300,6 +305,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -347,6 +353,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -394,6 +401,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -441,6 +449,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -499,6 +508,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);


### PR DESCRIPTION
When used for authentication, the spec states that assertions should be in a `client_assertion` param.  This patch fixes the strategy to look for the assertion in that param, and thus allows requests that contain assertions as both credentials and grants.

The patch also checks that `client_assertion_type` matches the expected value for JWTs, allowing endpoints to use both JWT and SAML assertions, if needed.

References:

http://tools.ietf.org/html/draft-ietf-oauth-assertions-12#section-4.2
http://tools.ietf.org/html/draft-ietf-oauth-jwt-bearer-06#section-2.2
