### PR TITLE
Validate JWT for proper authentication

### DIFF
--- a/lib/passport-oauth2-jwt-bearer/strategy.js
+++ b/lib/passport-oauth2-jwt-bearer/strategy.js
@@ -2,6 +2,7 @@
 * Module dependencies.
 */
 var passport = require('passport'),
+    jwt = require('jws')
     util = require('util');
 
 
@@ -10,15 +11,19 @@ var passport = require('passport'),
 *
 * @api protected
 */
-function Strategy(options, verify) {
+function Strategy(options, key, verify) {
   if (typeof options == 'function') {
-    verify = options;
-    options = {};
+    verify = key;
+    key = options;
+    options = undefined;
   }
+  options = options || {};
+  
   if (!verify) throw new Error('OAuth 2.0 JWT bearer strategy requires a verify function');
 
   passport.Strategy.call(this);
   this.name = 'oauth2-jwt-bearer';
+  this._key = key;
   this._verify = verify;
   this._passReqToCallback = options.passReqToCallback;
 }
@@ -39,51 +44,101 @@ Strategy.prototype.authenticate = function(req) {
     return this.fail();
   }
 
-  var contents = [],
-      type  = req.body['client_assertion_type']
-      jwtBearer = req.body['client_assertion'],
-      separator = '.',
+  var type  = req.body['client_assertion_type'],
+      assertion = req.body['client_assertion'],
       self = this;
 
   if (type != 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer') {
     return this.fail();
   }
 
-  contents = jwtBearer.split(separator);
-
-  if (!Array.isArray(contents)) { contents = [ contents ]; }
-
-  if (contents.length != 3) {
+  // Decode the JWT so the header and payload are available, as they contain
+  // fields needed to find the corresponding key.  Note that at this point, the
+  // assertion has not actually been verified.  It will be verified later, after
+  // the keying material has been retrieved.
+  var token = jwt.decode(assertion);
+  if (!token) {
     return this.fail();
   }
+  
+  var header = token.header
+    , payload = token.payload;
 
-  function verified(err, client, info) {
-    if (err) { return self.error(err); }
-    if (!client) { return self.fail(); }
-    self.success(client, info);
+  // TODO: Check that we are the intended audience
+
+  function doVerifyStep() {
+    function verified(err, client, info) {
+      if (err) { return self.error(err); }
+      if (!client) { return self.fail(); }
+      self.success(client, info);
+    }
+    
+    // At this point, the assertion has been verified and authentication can
+    // proceed.  Call the verify callback so the application can find and verify
+    // the client instance.  Typically, the subject and issuer of the assertion
+    // are the same, as the client is authenticating as itself.
+    try {
+      if (self._passReqToCallback) {
+        var arity = self._key.length;
+        if (arity == 4) {
+          // This variation allows the application to detect the case in which
+          // the issuer and subject of the assertion are different, and permit
+          // or deny as necessary.
+          self._verify(req, payload.iss || header.iss, header, verified);
+        } else { // arity == 3
+          self._verify(req, payload.iss || header.iss, keyed);
+        }
+      } else {
+        var arity = self._key.length;
+        if (arity == 3) {
+          // This variation allows the application to detect the case in which
+          // the issuer and subject of the assertion are different, and permit
+          // or deny as necessary.
+          self._verify(payload.sub || payload.iss, payload.iss, verified);
+        } else { // arity == 2
+          self._verify(payload.sub || payload.iss, verified);
+        }
+      }
+    } catch (ex) {
+      return self.error(ex);
+    }
   }
 
-  function base64urlDecode(str) {
-    return new Buffer(base64urlUnescape(str), 'base64').toString();
+  function doKeyStep() {
+    function keyed(err, key) {
+      if (err) { return self.error(err); }
+      if (!key) { return self.fail(); }
+      
+      // The key has been retrieved, verify the assertion.  `key` is a PEM
+      // encoded RSA public key, DSA public key, or X.509 certificate, as
+      // supported by Node's `crypto` module.
+      var ok = jwt.verify(assertion, key);
+      if (!ok) { return self.fail(); }
+      doVerifyStep();
+    }
+    
+    try {
+      if (self._passReqToCallback) {
+        var arity = self._key.length;
+        if (arity == 4) {
+          self._key(req, payload.iss || header.iss, header, keyed);
+        } else { // arity == 3
+          self._key(req, payload.iss || header.iss, keyed);
+        }
+      } else {
+        var arity = self._key.length;
+        if (arity == 3) {
+          self._key(payload.iss || header.iss, header, keyed);
+        } else { // arity == 2
+          self._key(payload.iss || header.iss, keyed);
+        }
+      }
+    } catch (ex) {
+      return self.error(ex);
+    }
   }
 
-  function base64urlUnescape(str) {
-    str += Array(5 - str.length % 4).join('=');
-    return str.replace(/\-/g, '+').replace(/_/g, '/');
-  }
-
-  // contents[0] = header, contents[1] = claimSet, contents[2] = signature
-  var claimSet = JSON.parse(base64urlDecode(contents[1]));
-
-  if (!claimSet || !claimSet.iss) {
-    return this.fail();
-  }
-
-  if (self._passReqToCallback) {
-    this._verify(req, claimSet.iss, verified);
-  } else {
-    this._verify(claimSet.iss, verified);
-  }
+  doKeyStep();
 };
 
 

--- a/lib/passport-oauth2-jwt-bearer/strategy.js
+++ b/lib/passport-oauth2-jwt-bearer/strategy.js
@@ -35,12 +35,12 @@ util.inherits(Strategy, passport.Strategy);
 * @api protected
 */
 Strategy.prototype.authenticate = function(req) {
-  if (!req.body || (!req.body['assertion'])) {
+  if (!req.body || (!req.body['client_assertion'])) {
     return this.fail();
   }
 
   var contents = [],
-      jwtBearer = req.body['assertion'],
+      jwtBearer = req.body['client_assertion'],
       separator = '.',
       self = this;
 

--- a/lib/passport-oauth2-jwt-bearer/strategy.js
+++ b/lib/passport-oauth2-jwt-bearer/strategy.js
@@ -35,14 +35,19 @@ util.inherits(Strategy, passport.Strategy);
 * @api protected
 */
 Strategy.prototype.authenticate = function(req) {
-  if (!req.body || (!req.body['client_assertion'])) {
+  if (!req.body || (!req.body['client_assertion_type'] || !req.body['client_assertion'])) {
     return this.fail();
   }
 
   var contents = [],
+      type  = req.body['client_assertion_type']
       jwtBearer = req.body['client_assertion'],
       separator = '.',
       self = this;
+
+  if (type != 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer') {
+    return this.fail();
+  }
 
   contents = jwtBearer.split(separator);
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   "main": "./lib/passport-oauth2-jwt-bearer",
   "dependencies": {
     "pkginfo": "0.2.x",
-    "passport": "~0.1.1"
+    "passport": "~0.1.1",
+    "jws": "0.2.x"
   },
   "devDependencies": {
     "vows": "0.6.x"

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -59,7 +59,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -110,7 +110,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -160,7 +160,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -205,7 +205,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -253,7 +253,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         //req.body = {};
-        //req.body['assertion'] = contents.join('.');
+        //req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -300,7 +300,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -347,7 +347,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -394,7 +394,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -441,7 +441,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });
@@ -499,7 +499,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
-        req.body['assertion'] = contents.join('.');
+        req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
         });

--- a/test/strategy-test.js
+++ b/test/strategy-test.js
@@ -59,6 +59,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -110,6 +111,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -160,6 +162,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -205,6 +208,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -253,6 +257,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         //req.body = {};
+        //req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         //req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -300,6 +305,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -347,6 +353,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -394,6 +401,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -441,6 +449,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);
@@ -499,6 +508,7 @@ vows.describe('ClientJWTBearerStrategy').addBatch({
         };
 
         req.body = {};
+        req.body['client_assertion_type'] = 'urn:ietf:params:oauth:client-assertion-type:jwt-bearer';
         req.body['client_assertion'] = contents.join('.');
         process.nextTick(function () {
           strategy.authenticate(req);


### PR DESCRIPTION
This patch introduces a `key` callback, which is used to load the keying material needed to verify the assertion.  The JWT is then actually verified using this key, and authentication proceeds if the assertion is valid and fails if it is not.

This fixes #6, and is critical for security.

I have not yet had the chance to update (and expand) the test cases.
